### PR TITLE
Select spellName via CombatLogGetCurrentEventInfo

### DIFF
--- a/SpellNotifications.lua
+++ b/SpellNotifications.lua
@@ -42,7 +42,7 @@ function SpellNotifications_OnLoad(self)
 	self:RegisterEvent("ACTIONBAR_UPDATE_STATE");
 end
 
-function SpellNotifications_OnEvent(event,...)
+function SpellNotifications_OnEvent(event)
 
 	local currentSpec = GetSpecialization()
 	local currentSpecName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
@@ -205,7 +205,7 @@ function SpellNotifications_OnEvent(event,...)
 	end
 	if (event=="SPELL_DAMAGE") then
 		if bit.band(destFlags, COMBATLOG_OBJECT_AFFILIATION_MINE) > 0 then
-			local spellName = select(13,...)
+			local spellName = select(13, CombatLogGetCurrentEventInfo())
 			if (destName=="Grounding Totem") then
 				SpellNotifications_Print("Grounded "..spellName..".","white","small")
 			end


### PR DESCRIPTION
An error occurs when grounding a spell:

```
2x ...aceSpellNotifications\SpellNotifications-2.0.0.lua:210: attempt to concatenate local 'spellName' (a nil value)
...aceSpellNotifications\SpellNotifications-2.0.0.lua:210: in function `SpellNotifications_OnEvent'
[string "*:OnEvent"]:1: in function <[string "*:OnEvent"]:1>

Locals:
InCombatSkipped
```

For the same reason as described in the [8.0 update notes](https://us.battle.net/forums/en/wow/topic/20762318007), the `spellName` should be `select`-ed from `CombatLogGetCurrentEventInfo`.

>Combat Log Event Changes
>The `COMBAT_LOG_EVENT` & `COMBAT_LOG_EVENT_UNFILTERED` events no longer have any event payload. In order to get the information passed down previously with these events, please use the `CombatLogGetCurrentEventInfo` function.
