### PR TITLE
Fixed resistMethod for SPELL_MISSED event

### DIFF
--- a/SpellNotifications.lua
+++ b/SpellNotifications.lua
@@ -159,7 +159,7 @@ function SpellNotifications.OnEvent(event)
 				MySpellGrounded = true;
 			elseif (missType=="REFLECT") then
 				MySpellReflected = true;
-			else
+			elseif (resistMethod==nil) then
 				resistMethod = "missed"
 			end
 


### PR DESCRIPTION
I noticed while I was leveling that i got "missed" when my spells were resisted.